### PR TITLE
Updates changelog for 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.0.0] 2026-03-22
 
 ### Added
 - v2 Docker image with Ubuntu 24.04, .NET 8.0, ODBC drivers (MySQL, PostgreSQL, SQL Server), CLI tools, PowerShell, dbpatch v2


### PR DESCRIPTION
Prepares the project for its 1.0.0 release by updating the changelog. Officially marks the next version as 1.0.0 with a release date.

Closes #22 