### PR TITLE
Fix GitVersion by enabling fetch-tags in checkout

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v3.2.0


### PR DESCRIPTION
## Summary

- Add `fetch-tags: true` to the checkout step in the Release workflow's version job
- `actions/checkout@v4` defaults `fetch-tags` to `false`, so GitVersion had no tags to work with and output `undefined`

Closes #23

## Test plan

- [ ] Re-run release workflow after merge — GitVersion should produce valid JSON output
- [ ] Delete and re-push `v1.0.0` tag to trigger a new release run